### PR TITLE
Make Raw Context Extendable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/src/Cevou/Behat/ScreenshotCompareExtension/Context/RawScreenshotCompareContext.php
+++ b/src/Cevou/Behat/ScreenshotCompareExtension/Context/RawScreenshotCompareContext.php
@@ -9,8 +9,8 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 class RawScreenshotCompareContext extends RawMinkContext implements ScreenshotCompareAwareContext
 {
-    private $screenshotCompareConfigurations;
-    private $screenshotCompareParameters;
+    protected $screenshotCompareConfigurations;
+    protected $screenshotCompareParameters;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
## Changes
- Made `RawScreenshotCompareContext` extendable by making it's data members protected rather than private, so that extending classes that wish to add functionality can access parameter and configuration data.
